### PR TITLE
fix(input): inherit font from above

### DIFF
--- a/src/styles/Terminal.scss
+++ b/src/styles/Terminal.scss
@@ -62,7 +62,8 @@
 }
 
 .terminal-main-input {
-  font-size: 0.9em
+  font: inherit;
+  font-size: 0.9em;
 }
 
 .terminal-container-main {


### PR DESCRIPTION
This will inherit the font family etc. from the main styling, to be styled with the correct font. Safari for example has `font-family: -apple-system` on inputs by default