### PR TITLE
Change the default value of watchConsoleLogging to match docs

### DIFF
--- a/src/js/components/types.js
+++ b/src/js/components/types.js
@@ -86,7 +86,7 @@ export const TerminalDefaultProps = {
   backgroundColor: 'black',
   commands: {},
   descriptions: {},
-  watchConsoleLogging: true,
+  watchConsoleLogging: false,
   commandPassThrough: false,
   promptSymbol: '>',
   plugins: [],


### PR DESCRIPTION
The readme claims that `watchConsoleLogging` defaults to `false`.  But it was actually defaulting to `true`.

This PR changes the default value to `false` to match the docs.