### PR TITLE
Fix typescript types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -9,7 +9,7 @@ declare module 'terminal-in-react' {
         backgroundColor?: string;
         prompt?: string;
         barColor?: string;
-        description?: {};
+        descriptions?: {};
         commands?: {};
         msg?: string;
         watchConsoleLogging?: boolean;


### PR DESCRIPTION
Fix of the issue mentioned in #68 - the main Typescript API is broken, stating `description` instead of `descriptions`. 