### PR TITLE
add github actions CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,31 @@
+name: ci
+
+on: [push]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [8.x, 10.x, 12.x]
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+
+    - name: yarn install
+      run: yarn install
+
+    - name: lint
+      run: yarn run lint
+
+    - name: build
+      run: yarn run build
+
+    - name: test
+      run: yarn run test


### PR DESCRIPTION
**notes**:

  - this doesn't test using storybook (let's save that for another PR)
  - to see the CI results, check out the [actions on my fork](https://github.com/jethrodaniel/terminal-in-react/actions/runs/65086233), since Github won't run them for _this_ repo until the workflow _actually exists_ in this repo.