### PR TITLE
fix `command -h` problems

### DIFF
--- a/src/js/args/option.js
+++ b/src/js/args/option.js
@@ -1,4 +1,8 @@
 export default function (name, description, defaultValue, init) {
+  // prevent adding twice
+  if (this.details.options.find(flagName => flagName.name == name)) {
+    return this;
+  }
   let usage = [];
 
   const assignShort = (n, options, short) => {
@@ -27,6 +31,7 @@ export default function (name, description, defaultValue, init) {
   }
 
   const optionDetails = {
+    name,
     defaultValue,
     usage,
     description,

--- a/src/js/args/utils.js
+++ b/src/js/args/utils.js
@@ -175,7 +175,8 @@ export default {
 
   generateDetails(kind) {
     // Get all properties of kind from global scope
-    const items = typeof kind === 'string' ? [...this.details[kind]] : [...kind];
+    const prop = typeof kind === 'string' ? [...this.details[kind]] : [...kind];    
+    const items = JSON.parse(JSON.stringify(prop));
     const parts = [];
     const isCmd = kind === 'commands';
 


### PR DESCRIPTION
You can reproduce the problems by using `help -h` twice.

The problems when using `command -h` are

1. duplicate help message after using `-h`
2. cannot read default value of the option properly after using `-h`

This PR fix them by 

1. prevent adding options that have the same name as existing ones
2. prevent modifying `option.usage` from Object to string