### PR TITLE
Add functionality to disable builtin commands

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -25,5 +25,6 @@ declare module 'terminal-in-react' {
             handleMaximise?: (toggleMaximise: () => void) => void;
             handleMinimise?: (toggleMinimise: () => void) => void;
         };
+        disableBuiltin?: boolean;
     }> {}
 }

--- a/src/js/components/Terminal/index.js
+++ b/src/js/components/Terminal/index.js
@@ -389,6 +389,8 @@ class Terminal extends Component {
     pluginMap(this.props.plugins, (PluginClass, config) => {
       try {
         const api = {
+          updateLine: this.updateLine.bind(this, instance),
+          getLines: this.getLines.bind(this, instance),
           printLine: this.printLine.bind(this, instance),
           removeLine: this.removeLine.bind(this, instance),
           runCommand: this.runCommand.bind(this, instance),
@@ -756,6 +758,17 @@ class Terminal extends Component {
     if (typeof pos === 'number') {
       instance.focusInput();
     }
+  }
+
+  getLines = (instance) => {
+    const { summary } = instance.state;
+    return summary;
+  }
+
+  updateLine = (instance, lineNumber, value) => {
+    const { summary } = instance.state;
+    summary[lineNumber] = value;
+    instance.setState({ summary });
   }
 
   // Print the summary (input -> output)

--- a/src/js/components/Terminal/index.js
+++ b/src/js/components/Terminal/index.js
@@ -75,7 +75,7 @@ class Terminal extends Component {
 
     this.pluginData = {};
 
-    this.defaultCommands = {
+    this.defaultCommands = props.disableBuiltin ? {} : {
       // eslint-disable-line react/sort-comp
       show: this.showMsg,
       clear: {
@@ -101,7 +101,7 @@ class Terminal extends Component {
       },
     };
 
-    this.defaultDesciptions = {
+    this.defaultDesciptions = props.disableBuiltin ? {} : {
       show: (props.msg && props.msg.length > 0) ? 'show the msg' : false,
       clear: 'clear the screen',
       help: 'list all the commands',

--- a/src/js/components/types.js
+++ b/src/js/components/types.js
@@ -54,6 +54,7 @@ export const TerminalPropTypes = {
   }),
   afterChange: PropTypes.func,
   commandWasRun: PropTypes.func,
+  disableBuiltin: PropTypes.bool,
 };
 
 export const TerminalContextTypes = {
@@ -95,4 +96,5 @@ export const TerminalDefaultProps = {
   promptSymbol: '>',
   plugins: [],
   shortcuts: {},
+  disableBuiltin: false,
 };


### PR DESCRIPTION
This allows me to run a passthrough show command, although on load, a show command is being called from somewhere.
I'm not too sure where that is happening. 