### PR TITLE
Update dependencies

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,8 +9,8 @@ I'm excited to have you helping out. Thank you so much for your time.
 Considering you've forked and cloned the repo on your system, switch to the directory and install the dependencies.
 
 ```
-npm install g babel-cli
-npm install g webpack-cli
+npm install -g babel-cli
+npm install -g webpack-cli
 
 cd terminal-in-react
 npm install

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "prop-types": "^15.5.10",
     "react": "16.2.0",
     "react-dom": "16.2.0",
-    "react-object-inspector": "^0.2.1",
+    "react-inspector": "2.3.1",
     "string-similarity": "^1.2.0",
     "styled-components": "3.1.6",
     "whatkey": "^2.0.1"
@@ -48,6 +48,7 @@
     "jest": "22.2.2",
     "jsdom": "^11.1.0",
     "react-test-renderer": "16.2.0",
+    "terminal-in-react-node-eval-plugin": "2.0.0",
     "terminal-in-react-pseudo-file-system-plugin": "3.0.0",
     "webpack": "^3.1.0",
     "webpack-bundle-analyzer": "^2.8.2",

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-console */
 import React from 'react'; // eslint-disable-line
-import ObjectInspector from 'react-object-inspector';
+import { ObjectInspector } from 'react-inspector';
 import platform from 'platform';
 
 // Capture the console.log calls (hijacking)

--- a/yarn.lock
+++ b/yarn.lock
@@ -2507,6 +2507,11 @@ copy-descriptor@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
 
+core-decorators@0.20.0:
+  version "0.20.0"
+  resolved "https://registry.yarnpkg.com/core-decorators/-/core-decorators-0.20.0.tgz#605896624053af8c28efbe735c25a301a61c65c5"
+  integrity sha512-7cp/Pz3AmQXjRwhAsFN+8ndRiBNyLxtZgC/fhKvrwQTf2ZlZma6LnimoJPrOqgxZ0tIeI9VvSs+QKe0OPJ0SuA==
+
 core-decorators@^0.19.0:
   version "0.19.0"
   resolved "https://registry.yarnpkg.com/core-decorators/-/core-decorators-0.19.0.tgz#28c9b44aa6208902934627a28f4f5950bd5b463e"
@@ -5070,6 +5075,11 @@ js-tokens@^3.0.0, js-tokens@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
 
+"js-tokens@^3.0.0 || ^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
+  integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
+
 js-yaml@^3.4.3, js-yaml@^3.7.0, js-yaml@^3.9.1:
   version "3.10.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.10.0.tgz#2e78441646bd4682e963f22b6e92823c309c62dc"
@@ -5406,6 +5416,13 @@ loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.3.1:
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.3.1.tgz#d1a8ad33fa9ce0e713d65fdd0ac8b748d478c848"
   dependencies:
     js-tokens "^3.0.0"
+
+loose-envify@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
+  integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
+  dependencies:
+    js-tokens "^3.0.0 || ^4.0.0"
 
 loud-rejection@^1.0.0:
   version "1.6.0"
@@ -6623,6 +6640,15 @@ prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.6, prop-types@^15.5.8,
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
 
+prop-types@^15.6.1:
+  version "15.8.1"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
+  integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
+  dependencies:
+    loose-envify "^1.4.0"
+    object-assign "^4.1.1"
+    react-is "^16.13.1"
+
 proxy-addr@~2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/proxy-addr/-/proxy-addr-2.0.2.tgz#6571504f47bb988ec8180253f85dd7e14952bdec"
@@ -6814,12 +6840,26 @@ react-icons@^2.2.7:
   dependencies:
     react-icon-base "2.1.0"
 
+react-inspector@2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/react-inspector/-/react-inspector-2.3.1.tgz#f0eb7f520669b545b441af9d38ec6d706e5f649c"
+  integrity sha512-tUUK7t3KWgZEIUktOYko5Ic/oYwvjEvQUFAGC1UeMeDaQ5za2yZFtItJa2RTwBJB//NxPr000WQK6sEbqC6y0Q==
+  dependencies:
+    babel-runtime "^6.26.0"
+    is-dom "^1.0.9"
+    prop-types "^15.6.1"
+
 react-inspector@^2.2.2:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/react-inspector/-/react-inspector-2.2.2.tgz#c04f5248fa92ab6c23e37960e725fb7f48c34d05"
   dependencies:
     babel-runtime "^6.26.0"
     is-dom "^1.0.9"
+
+react-is@^16.13.1:
+  version "16.13.1"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
+  integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
 react-modal@^3.1.10:
   version "3.1.13"
@@ -7917,6 +7957,15 @@ tar@^2.2.1:
     fstream "^1.0.2"
     inherits "2"
 
+terminal-in-react-node-eval-plugin@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/terminal-in-react-node-eval-plugin/-/terminal-in-react-node-eval-plugin-2.0.0.tgz#5e65d0a63d997b8dfb4c48576f6b5683a035e79f"
+  integrity sha512-j+1DveRryqapV4iGr2/uFR55KJFt4jursgI9p/5mUHaAz5MxVxN0EOBTFCRbyoxus/DD68tQ4agV2IA+qli1vw==
+  dependencies:
+    core-decorators "0.20.0"
+    memoizerific "^1.11.2"
+    terminal-in-react "4.3.0"
+
 terminal-in-react-pseudo-file-system-plugin@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/terminal-in-react-pseudo-file-system-plugin/-/terminal-in-react-pseudo-file-system-plugin-3.0.0.tgz#382052c9dcf884e2f71884f69f30ad57c2b9b158"
@@ -7928,6 +7977,23 @@ terminal-in-react-pseudo-file-system-plugin@3.0.0:
     memoizerific "^1.11.2"
     react-syntax-highlighter "^5.6.2"
     terminal-in-react "^3.4.2"
+
+terminal-in-react@4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/terminal-in-react/-/terminal-in-react-4.3.0.tgz#bb4e6bc1fc7cce3e9c6f2d0faced452a75a5f8c3"
+  integrity sha512-Db4pQQJ3NcC3B+b40MpKAJ7JlWmgFSCtCNYdKEctFsXHc1jLnpl6xAy3ijaL6om63OJozne/6U4bUIs6g8uSjg==
+  dependencies:
+    lodash.camelcase "^4.3.0"
+    lodash.isequal "^4.5.0"
+    minimist "^1.2.0"
+    platform "^1.3.4"
+    prop-types "^15.5.10"
+    react "16.2.0"
+    react-dom "16.2.0"
+    react-object-inspector "^0.2.1"
+    string-similarity "^1.2.0"
+    styled-components "3.1.6"
+    whatkey "^2.0.1"
 
 terminal-in-react@^3.4.2:
   version "3.5.2"


### PR DESCRIPTION
Hey @nitin42 !

Hope you're doing well. I just wanted to give you a heads up about a pull request I submitted for your project. There were a couple of issues I encountered while using your project that I addressed in the pull request:

I noticed that the `@terminal-in-react-node-eval-plugin` dependency was missing, which caused an error when running `npm start`. I added this dependency to the project to fix the issue.

<img width="1475" alt="iShot_2023-06-13_11 14 41" src="https://github.com/nitin42/terminal-in-react/assets/100353458/f2989afb-cedd-4474-8eed-ba0948bd1020">

I also noticed that `react-object-inspector` was deprecated and causing issues during `npm install` as it was incompatible with React version 16.2.0. To resolve this, I updated the dependency to `react-inspector@2.3.1`, which is the recommended alternative.

<img width="692" alt="iShot_2023-06-13_10 59 09" src="https://github.com/nitin42/terminal-in-react/assets/100353458/52423d95-ac62-4763-bf73-f687814b55cc">

I think these changes will improve the stability and functionality of your project. Let me know if you have any questions or concerns. Thanks!